### PR TITLE
Fix version for distribute & zc.buildout

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -18,6 +18,7 @@ parts =
 develop = .
 
 [versions]
+distribute = 0.6.45
 pyramid = 1.3.2
 sqlahelper = 1.0
 waitress = 0.8.1
@@ -26,6 +27,7 @@ papyrus = 0.10dev1
 GeoAlchemy = 0.7.1
 OWSLib = 0.5.1
 fpdf = 1.7
+zc.buildout = 2.1.0
 
 [vars]
 


### PR DESCRIPTION
This PR fixes versions for `distribute` and `zc.buildout`.

If we don't fix them, we will not be able to use this project on the same server as the sitn_c2cgeoportal project.

Please read this PR, comment and tell me to merge it...
