### PR TITLE
Update buildout and egg versions

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,4 +1,5 @@
 [buildout]
+extends = versions.cfg
 index = http://pypi.camptocamp.net/pypi/
 
 develop-eggs-directory = buildout/develop-eggs
@@ -6,7 +7,8 @@ eggs-directory = buildout/eggs
 parts-directory = buildout/parts
 bin-directory = buildout/bin
 
-log-level = 1
+show-picked-versions = true
+
 versions = versions
  
 parts =
@@ -17,17 +19,8 @@ parts =
 
 develop = .
 
-[versions]
-distribute = 0.6.45
-pyramid = 1.3.2
-sqlahelper = 1.0
-waitress = 0.8.1
-SQLAlchemy = 0.7.9
-papyrus = 0.10dev1
-GeoAlchemy = 0.7.1
-OWSLib = 0.5.1
-fpdf = 1.7
-zc.buildout = 2.1.0
+newest = false
+prefer-final = true
 
 [vars]
 

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,0 +1,59 @@
+[versions]
+
+distribute = 0.6.45
+zc.buildout = 2.1.0
+zc.recipe.egg = 2.0.0
+
+pyramid = 1.3.4
+
+sqlahelper = 1.0
+waitress = 0.8.1
+SQLAlchemy = 0.7.9
+GeoAlchemy = 0.7.1
+papyrus = 0.10dev1
+OWSLib = 0.5.1
+fpdf = 1.7
+chameleon = 2.12
+geojson = 1.0.1
+mako = 0.9.0
+markupsafe = 0.18
+pastedeploy = 1.5.0
+pygments = 1.6
+repoze.lru = 0.6
+shapely = 1.2.18
+translationstring = 1.1
+venusian = 1.0a8
+webob = 1.2.3
+
+zope.deprecation = 4.0.2
+zope.interface = 4.0.5
+
+collective.recipe.modwsgi = 2.0
+jstools = 0.6
+z3c.recipe.filetemplate = 2.2.0
+
+# Required by:
+# crdppf==1.0
+httplib2 = 0.8
+pil = 1.1.7
+pyramid-debugtoolbar = 1.0.7
+pyramid-tm = 0.7
+zope.sqlalchemy = 0.7.2
+
+# Required by:
+# chameleon==2.12
+ordereddict = 1.1
+
+# Required by:
+# geojson==1.0.1
+simplejson = 3.3.0
+
+# Required by:
+# crdppf==1.0
+# pyramid-tm==0.7
+# zope.sqlalchemy==0.7.2
+transaction = 1.4.1
+
+# Required by:
+# chameleon==2.12
+unittest2 = 0.5.1


### PR DESCRIPTION
With this PR, we:
- fix the egg versions
- create a separate file for maintaining these version
- use option `show-picked-versions` (new in buildout 2.0.0)

NO NEED TO REVIEW

Merging.
