### PR TITLE
remove hard-coded IPs

### DIFF
--- a/apache/mapserver.conf.in
+++ b/apache/mapserver.conf.in
@@ -4,8 +4,7 @@ ScriptAlias /${vars:instanceid}/wmscrdppf ${mapserverexec}
    # the following lines:
    Order Deny,Allow
    Deny from all
-   Allow from 148.196 127.0.0.01
-#   ${vars:mapserv_allow}
+   ${vars:mapserv_allow}
    SetHandler cgi-script
    SetEnv MS_MAPFILE ${buildout:directory}/mapserver/crdppf.map
 </Location>

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -48,7 +48,7 @@ dbport = 5432
 db = overwrite_me
 
 # MAPSERVER
-mapserv_allow = Allow from ${vars:host}
+mapserv_allow = Allow from 127.0.0.1
 mapserverexec = overwrite_me
 # CRDPPF webapp definitions
 crdppf_wms = http://localhost/${vars:instanceid}/wmscrdppf


### PR DESCRIPTION
Fixes #174

@voisardf, please review

Note also that we will have to overwrite the default `mapserv_allow` buildout variable in our buildout file with `mapserv_allow = Allow from 148.196 127.0.0.01`. Otherwise, you won't anymore be able to use the WMS service in QGIS for instance.
