### PR TITLE
Make sure that eggs and public dirs permissions are OK for Linux

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -13,6 +13,7 @@ versions = versions
  
 parts =
     pyramid
+    fix-perm
     modwsgi
     template
     jsbuild
@@ -103,3 +104,19 @@ resource-dir = ${buildout:directory}/jsbuild
 config = ${jsbuild:resource-dir}/app.cfg
 output-dir = ${vars:project}/static/build
 compress = True
+
+[fix-perm]
+recipe = collective.recipe.cmd:py
+on_install = true
+on_update = true
+cmds =
+    >>> if sys.platform.startswith('linux'):
+    >>>    from subprocess import call, Popen, PIPE
+    >>>    call(['chmod', '--quiet', '-R', 'o+w', 'crdppf/static/public/pdf'])
+    >>>    call(['chmod', '--quiet', '-R', 'o+w', 'crdppf/static/public/temp_files'])
+    >>>    dirs = Popen(['find', '-type', 'd'], stdout=PIPE).communicate()[0]
+    >>>    for d in [d for d in dirs.split('\n') if len(d) > 0]:
+    >>>        call(['chmod', '--quiet', 'g+s', d])
+    >>>    call(['chmod', '--quiet', '-R', 'g+rw,o+r', '.'])
+    >>>    # remove wsgi file (rights issue)
+    >>>    call(['rm', '-f', 'buildout/parts/modwsgi/wsgi'])


### PR DESCRIPTION
As for now on a Linux system the pdf/ and tempfiles/ directories in crdppf/static/public are not writeable by the apache user (create an error when generating a PDF extract). I have also noticed permissions issues with the httplib2 egg.

This PR suggests to use a "fix-perm" system inspired by what is done in c2cgeoportal:
https://github.com/camptocamp/c2cgeoportal/blob/master/c2cgeoportal/scaffolds/update/CONST_buildout.cfg_tmpl#L103-L115
The commands are actually only executed for Linux systems.
