### PR TITLE
Mapfish print

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -19,6 +19,7 @@ parts =
     modwsgi
     template
     jsbuild
+    print-war
 
 develop = .
         crdppf_core
@@ -89,6 +90,10 @@ logon = overwrite_me
 # Waitress port
 waitress_port = overwrite_me
 
+# Print level logger (DEBUG if development else ERROR)
+print_level_logger = ERROR
+
+
 [pyramid]
 recipe = zc.recipe.egg
 dependent-scripts = true
@@ -132,3 +137,15 @@ cmds =
     >>>    call(['chmod', '--quiet', '-R', 'g+rw,o+r', '.'])
     >>>    # remove wsgi file (rights issue)
     >>>    call(['rm', '-f', 'buildout/parts/modwsgi/wsgi'])
+
+[print-war]
+recipe = c2c.recipe.jarfile
+mode = update
+basedir = crdppf_core/print/
+basewar = print-servlet.war
+input = ${print-war:basewar}
+    WEB-INF/classes/*.xml
+    print-apps/*
+
+
+output = C:/ApacheTomcat7/webapps/print-${vars:instanceid}.war

--- a/config_pdf.yaml.in
+++ b/config_pdf.yaml.in
@@ -82,3 +82,5 @@ pdf_config:
   placeholder: Placeholder.jpg
   pdfbasename: _ExtraitCRDPPF
   siteplanbasename: _siteplan
+
+print_url: http://localhost:8080/print-${vars:instanceid}/print/crdppf


### PR DESCRIPTION
Add some configuration for mapfish print.

@voisardf, if you plan to develop for mapfish print, then please ensure that both of your crdppf are on branch `mapfish_print`.

I began to write some release notes about it, thus them into account when you plan to work on Mapfish print:
https://github.com/sitn/crdppf_core/releases/tag/untagged-3e9adcd20ed7415fbf05