### PR TITLE
Added all elements needed to display the empty federal topics

### DIFF
--- a/config_db.yaml.in
+++ b/config_db.yaml.in
@@ -29,6 +29,13 @@ db_config:
       att_property_type: typimm
       att_property_source: source
     #optional:
+    # dev instance
+    local_names:
+      tablename: nom_local_lieu_dit
+      schema: public
+      att_id: idcnlo
+      att_local_name: nomloc
+    # prod instance
     #~ local_names:
       #~ tablename: mo25_noms_locaux
       #~ schema: mensuration

--- a/config_db.yaml.in
+++ b/config_db.yaml.in
@@ -29,15 +29,19 @@ db_config:
       att_property_type: typimm
       att_property_source: source
     #optional:
-    local_names:
-      tablename: mo25_noms_locaux
-      schema: mensuration
-      att_id: idcnlo
-      att_local_name: nomloc
+    #~ local_names:
+      #~ tablename: mo25_noms_locaux
+      #~ schema: mensuration
+      #~ att_id: idcnlo
+      #~ att_local_name: nomloc
 
   restrictions:
+      railways_project_zones
+      railways_construction_limits
+      highways_project_zones
       airport_security_zones
       airport_project_zones
+      airport_construction_limits
       airport_polluted_sites
       transportation_polluted_sites
       road_noise

--- a/config_pdf.yaml.in
+++ b/config_pdf.yaml.in
@@ -24,7 +24,7 @@ app_config:
     - parcelles
     - ag1_parcellaire_provisoire
     - mo9_immeubles
-    #- mo9_text_group
+    # not working on dev - mo9_text_group
     - mo7_obj_divers_lineaire
     - mo7_obj_divers_couvert
     - mo7_obj_divers_piscine

--- a/config_pdf.yaml.in
+++ b/config_pdf.yaml.in
@@ -24,7 +24,7 @@ app_config:
     - parcelles
     - ag1_parcellaire_provisoire
     - mo9_immeubles
-    - mo9_text_group
+    #- mo9_text_group
     - mo7_obj_divers_lineaire
     - mo7_obj_divers_couvert
     - mo7_obj_divers_piscine

--- a/mapserver/crdppf.map.in
+++ b/mapserver/crdppf.map.in
@@ -103,7 +103,7 @@ LAYER
     "wms_srs" "epsg:21781"
     "wfs_enable_request" "*"
     "gml_types" "auto"
-    "gml_include_items" "idemai,cadastre,nummai,typimm,srfmai,source,url_terris"
+    "gml_include_items" "idemai,cadastre,nummai,typimm,srfmai,source,nufeco,valide"
   END
   PROJECTION
     "init=epsg:21781"   ##required
@@ -904,6 +904,77 @@ LAYER
 END
 
 LAYER
+  NAME "r87_astra_projektierungszonen_nationalstrassen"
+  STATUS ON
+  METADATA
+       "ows_title"                      "r87_astra_projektierungszonen_nationalstrassen"
+       "wms_srs"                    "epsg:21781"
+       "wms_title"                      "${vars:instanceid} WMS Server"
+       "wms_onlineresource"     "http://${vars:host}/${vars:instanceid}/wmscrdppf"
+       "wms_srs"                    "EPSG:21781" 
+  END
+  CONNECTIONTYPE POSTGIS
+  CONNECTION "user=${vars:dbuser} password=${vars:dbpassword} dbname=${vars:db} host=${vars:dbhost} port=${vars:dbport}"
+  PROCESSING "CLOSE_CONNECTION=DEFER"
+  DATA "geom from crdppf.r87_astra_projektierungszonen_nationalstrassen using unique idobj using srid=21781"
+  TYPE POLYGON
+  TEMPLATE "ttt"
+  OPACITY 60
+  CLASS
+    NAME "Zones réservées des routes nationales"
+    COLOR 0 220 220
+    OUTLINECOLOR 0 180 180
+   END
+END
+
+LAYER
+  NAME "r96_bav_projektierungszonen_eisenbahnanlagen"
+  STATUS ON
+  METADATA
+       "ows_title"                      "r96_bav_projektierungszonen_eisenbahnanlagen"
+       "wms_srs"                    "epsg:21781"
+       "wms_title"                      "${vars:instanceid} WMS Server"
+       "wms_onlineresource"     "http://${vars:host}/${vars:instanceid}/wmscrdppf"
+       "wms_srs"                    "EPSG:21781" 
+  END
+  CONNECTIONTYPE POSTGIS
+  CONNECTION "user=${vars:dbuser} password=${vars:dbpassword} dbname=${vars:db} host=${vars:dbhost} port=${vars:dbport}"
+  PROCESSING "CLOSE_CONNECTION=DEFER"
+  DATA "geom from crdppf.r96_bav_projektierungszonen_eisenbahnanlagen using unique idobj using srid=21781"
+  TYPE POLYGON
+  TEMPLATE "ttt"
+  OPACITY 60
+  CLASS
+    NAME "Zones réservées des inst. ferrovières"
+    COLOR 220 220 0
+    OUTLINECOLOR 180 180 0
+   END
+END
+
+LAYER
+  NAME "r97_bav_baulinien_eisenbahnanlagen"
+  STATUS ON
+  METADATA
+       "ows_title"                      "r97_bav_baulinien_eisenbahnanlagen"
+       "wms_srs"                    "epsg:21781"
+       "wms_title"                      "${vars:instanceid} WMS Server"
+       "wms_onlineresource"     "http://${vars:host}/${vars:instanceid}/wmscrdppf"
+       "wms_srs"                    "EPSG:21781" 
+  END
+  CONNECTIONTYPE POSTGIS
+  CONNECTION "user=${vars:dbuser} password=${vars:dbpassword} dbname=${vars:db} host=${vars:dbhost} port=${vars:dbport}"
+  PROCESSING "CLOSE_CONNECTION=DEFER"
+  DATA "geom from crdppf.r97_bav_baulinien_eisenbahnanlagen using unique idobj using srid=21781"
+  TYPE LINE
+  TEMPLATE "ttt"
+  OPACITY 60
+  CLASS
+    NAME "Aligenements des install. ferrovières"
+    COLOR 220 220 0
+   END
+END
+
+LAYER
   NAME "r103_bazl_projektierungszonen_flughafenanlagen"
   STATUS ON
   METADATA
@@ -924,6 +995,29 @@ LAYER
     NAME "Zones rés. des install. aéroportuaires"
     COLOR 255 230 180
     OUTLINECOLOR 255 170 0
+   END
+END
+
+LAYER
+  NAME "r104_bazl_baulinien_flughafenanlagen"
+  STATUS ON
+  METADATA
+       "ows_title"                      "r104_bazl_baulinien_flughafenanlagen"
+       "wms_srs"                    "epsg:21781"
+       "wms_title"                      "${vars:instanceid} WMS Server"
+       "wms_onlineresource"     "http://${vars:host}/${vars:instanceid}/wmscrdppf"
+       "wms_srs"                    "EPSG:21781" 
+  END
+  CONNECTIONTYPE POSTGIS
+  CONNECTION "user=${vars:dbuser} password=${vars:dbpassword} dbname=${vars:db} host=${vars:dbhost} port=${vars:dbport}"
+  PROCESSING "CLOSE_CONNECTION=DEFER"
+  DATA "geom from crdppf.r104_bazl_baulinien_flughafenanlagen using unique idobj using srid=21781"
+  TYPE LINE
+  TEMPLATE "ttt"
+  OPACITY 60
+  CLASS
+    NAME "Aligenements des install. aéroportuaires"
+    COLOR 0 0 180
    END
 END
 


### PR DESCRIPTION
This PR serves to add empty layers for all the federal topics that exists, do not contain restriction objects so far.

Prerequisits are:
- the classes have to be defined in the core : https://github.com/sitn/crdppf_core/blob/master/crdppf/models.py - it's done by default now
- the classes are linked in the table2model file in the core: https://github.com/sitn/crdppf_core/blob/master/crdppf/util/table2model_match.py - should by done by default now
- the translations table contains the layer labels : done in latest update of translations table

The PR adds 
- the layer definitions in the mapfile
- the layers in the db_config.yaml.in file for the buildout
- the missing federal municipality number as defined by the federal office of statistics and the legal state of a property

The other changes in the config_db.yaml.in and config_pdf.yaml.in are optional as they are related to your local WMS and DB configurations

NO NEED TO REVIEW - I will merge it when done with testing.